### PR TITLE
Symlink also to /usr/local/bin/composer

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,4 +22,10 @@ class composer::install {
     ensure => link,
     target => "${composer::install_dir}/composer.phar"
   }
+
+  file { '/usr/local/bin/composer':
+    ensure => 'link',
+    target => "${composer::install_dir}/composer.phar"
+  }
+
 }


### PR DESCRIPTION
Sometimes we just use "composer" as recommended in official docs: https://getcomposer.org/doc/00-intro.md